### PR TITLE
adding 1x modules

### DIFF
--- a/modules/ossm-cr-threescale-1x.adoc
+++ b/modules/ossm-cr-threescale-1x.adoc
@@ -3,7 +3,7 @@
 // * service_mesh/v1x/customizing-installation-ossm.adoc
 // * service_mesh/v2x/customizing-installation-ossm.adoc
 
-[id="ossm-cr-threescale_{context}"]
+[id="ossm-cr-threescale-1x_{context}"]
 
 = 3scale configuration
 
@@ -27,6 +27,9 @@ threeScale:
   PARAM_THREESCALE_ALLOW_INSECURE_CONN: false
   PARAM_THREESCALE_CLIENT_TIMEOUT_SECONDS: 10
   PARAM_THREESCALE_GRPC_CONN_MAX_SECONDS: 60
+  PARAM_USE_CACHED_BACKEND: false
+  PARAM_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS: 15
+  PARAM_BACKEND_CACHE_POLICY_FAIL_CLOSED: true
 ----
 
 .3scale parameters
@@ -102,4 +105,19 @@ threeScale:
 |Sets the maximum amount of seconds (+/-10% jitter) a connection may exist before it is closed
 |Time period in seconds
 |60
+
+|`PARAM_USE_CACHE_BACKEND`
+|If true, attempt to create an in-memory apisonator cache for authorization requests
+|`true`/`false`
+|`false`
+
+|`PARAM_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS`
+|If the backend cache is enabled, this sets the interval in seconds for flushing the cache against 3scale
+|Time period in seconds
+|15
+
+|`PARAM_BACKEND_CACHE_POLICY_FAIL_CLOSED`
+|Whenever the backend cache cannot retrieve authorization data, whether to deny (closed) or allow (open) requests
+|`true`/`false`
+|`true`
 |===

--- a/modules/ossm-threescale-integrate-1x.adoc
+++ b/modules/ossm-threescale-integrate-1x.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v1x/threescale_adapter/threescale-adapter.adoc
+// * service_mesh/v2x/threescale_adapter/threescale-adapter.adoc
+
+[id="ossm-threescale-integrate-1x_{context}"]
+= Integrate the 3scale adapter with {ProductName}
+
+You can use these examples to configure requests to your services using the 3scale Istio Adapter.
+
+
+.Prerequisites:
+
+* {ProductName} version 1.x
+* A working 3scale account (link:https://www.3scale.net/signup/[SaaS] or link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.5/html/installing_3scale/onpremises-installation[3scale 2.5 On-Premises])
+* Enabling backend cache requires 3scale 2.9 or greater
+* {ProductName} prerequisites
+* Ensure Mixer policy enforcement is enabled. Update Mixer policy enforcement section provides instructions to check the current Mixer policy enforcement status and enable policy enforcement.
+
+IMPORTANT: When you want to enable 3scale backend cache with the 3scale Istio adapter, you must also enable mixer policy and mixer telemetry. See xref:../../service_mesh/v2x/installing-ossm.adoc#ossm-control-plane-deploy_installing-ossm[Deploying the Red Hat OpenShift Service Mesh control plane].
+
+[NOTE]
+====
+To configure the 3scale Istio Adapter, refer to {ProductName} custom resources for instructions on adding adapter parameters to the custom resource file.
+====
+
+
+[NOTE]
+====
+Pay particular attention to the `kind: handler` resource. You must update this with your 3scale credentials and the service ID of the API you want to manage.
+====
+
+. Modify the handler configuration with your 3scale configuration.
++
+.Handler configuration example
+[source,yaml]
+----
+  apiVersion: "config.istio.io/v1alpha2"
+  kind: handler
+  metadata:
+   name: threescale
+  spec:
+   adapter: threescale
+   params:
+     service_id: "<SERVICE_ID>"
+     system_url: "https://<organization>-admin.3scale.net/"
+     access_token: "<ACCESS_TOKEN>"
+   connection:
+     address: "threescale-istio-adapter:3333"
+----
+
+Optionally, you can provide a `backend_url` field within the _params_ section to override the URL provided by the 3scale configuration. This may be useful if the adapter runs on the same cluster as the 3scale on-premise instance, and you wish to leverage the internal cluster DNS.
+
+. Modify the rule configuration with your 3scale configuration to dispatch the rule to the threescale handler.
++
+.Rule configuration example
+[source,yaml]
+----
+  apiVersion: "config.istio.io/v1alpha2"
+  kind: rule
+  metadata:
+    name: threescale
+  spec:
+    match: destination.labels["service-mesh.3scale.net"] == "true"
+    actions:
+      - handler: threescale.handler
+        instances:
+          - threescale-authorization.instance
+----

--- a/modules/ossm-threescale-metrics-1x.adoc
+++ b/modules/ossm-threescale-metrics-1x.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v1x/threescale_adapter/threescale-adapter.adoc
+// * service_mesh/v2x/threescale_adapter/threescale-adapter.adoc
+
+[id="ossm-threescale-metrics-1x_{context}"]
+= 3scale Adapter metrics
+The adapter, by default reports various Prometheus metrics that are exposed on port `8080` at the `/metrics` endpoint. These metrics provide insight into how the interactions between the adapter and 3scale are performing. The service is labeled to be automatically discovered and scraped by Prometheus.

--- a/modules/threescale-backend-cache.adoc
+++ b/modules/threescale-backend-cache.adoc
@@ -5,6 +5,7 @@
 
 [id="threescale-backend-cache_{context}"]
 = 3scale backend cache
+
 The 3scale backend cache provides an authorization and reporting cache for clients of the 3scale Service Management API. This cache is embedded in the adapter to enable lower latencies in responses in certain situations assuming the administrator is willing to accept the trade-offs.
 
 NOTE: 3scale backend cache is disabled by default. 3scale backend cache functionality trades inaccuracy in rate limiting and potential loss of hits since the last flush was performed for low latency and higher consumption of resources in the processor and memory.

--- a/modules/threescale-istio-adapter-apicast.adoc
+++ b/modules/threescale-istio-adapter-apicast.adoc
@@ -5,6 +5,7 @@
 
 [id="threescale-istio-adapter-apicast_{context}"]
 = 3scale Istio Adapter APIcast emulation
+
 The 3scale Istio Adapter performs as APIcast would when the following conditions occur:
 
 * When a request cannot match any mapping rule defined, the returned HTTP code is 404 Not Found. This was previously 403 Forbidden.

--- a/service_mesh/v1x/customizing-installation-ossm.adoc
+++ b/service_mesh/v1x/customizing-installation-ossm.adoc
@@ -36,7 +36,7 @@ include::modules/ossm-jaeger-config-elasticsearch.adoc[leveloffset=+2]
 
 For more information about configuring Elasticsearch with {product-title}, see  xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store].
 
-include::modules/ossm-cr-threescale.adoc[leveloffset=+1]
+include::modules/ossm-cr-threescale-1x.adoc[leveloffset=+1]
 
 
 == Next steps

--- a/service_mesh/v1x/threescale-adapter.adoc
+++ b/service_mesh/v1x/threescale-adapter.adoc
@@ -8,7 +8,7 @@ The 3scale Istio Adapter is an optional adapter that allows you to label a servi
 It is not required for {ProductName}.
 
 
-include::modules/ossm-threescale-integrate.adoc[leveloffset=+1]
+include::modules/ossm-threescale-integrate-1x.adoc[leveloffset=+1]
 
 include::modules/ossm-threescale-cr.adoc[leveloffset=+2]
 
@@ -24,4 +24,4 @@ include::modules/ossm-threescale-caching.adoc[leveloffset=+1]
 
 include::modules/ossm-threescale-authentication.adoc[leveloffset=+1]
 
-include::modules/ossm-threescale-metrics.adoc[leveloffset=+1]
+include::modules/ossm-threescale-metrics-1x.adoc[leveloffset=+1]


### PR DESCRIPTION
@dfennessy @fbolton, I think this PR might fix the issue, or at least get us closer. @JStickler, if you get a chance, can you take a look too?

I think the issue is that we have two versions of our docs which is inside of OCP which is also versioned. So we have a folder-version architecture instead of a branch version architecture. OCP is using the branch versioned architecture, which ties our hands.

Since Darren made changes to the some of the modules for v2, and as a result we need to create v1 versions of some modules.