### PR TITLE
link fixes and 1x correction

### DIFF
--- a/modules/ossm-cr-threescale-1x.adoc
+++ b/modules/ossm-cr-threescale-1x.adoc
@@ -27,9 +27,6 @@ threeScale:
   PARAM_THREESCALE_ALLOW_INSECURE_CONN: false
   PARAM_THREESCALE_CLIENT_TIMEOUT_SECONDS: 10
   PARAM_THREESCALE_GRPC_CONN_MAX_SECONDS: 60
-  PARAM_USE_CACHED_BACKEND: false
-  PARAM_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS: 15
-  PARAM_BACKEND_CACHE_POLICY_FAIL_CLOSED: true
 ----
 
 .3scale parameters
@@ -105,19 +102,4 @@ threeScale:
 |Sets the maximum amount of seconds (+/-10% jitter) a connection may exist before it is closed
 |Time period in seconds
 |60
-
-|`PARAM_USE_CACHE_BACKEND`
-|If true, attempt to create an in-memory apisonator cache for authorization requests
-|`true`/`false`
-|`false`
-
-|`PARAM_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS`
-|If the backend cache is enabled, this sets the interval in seconds for flushing the cache against 3scale
-|Time period in seconds
-|15
-
-|`PARAM_BACKEND_CACHE_POLICY_FAIL_CLOSED`
-|Whenever the backend cache cannot retrieve authorization data, whether to deny (closed) or allow (open) requests
-|`true`/`false`
-|`true`
 |===

--- a/modules/ossm-cr-threescale.adoc
+++ b/modules/ossm-cr-threescale.adoc
@@ -27,6 +27,9 @@ threeScale:
   PARAM_THREESCALE_ALLOW_INSECURE_CONN: false
   PARAM_THREESCALE_CLIENT_TIMEOUT_SECONDS: 10
   PARAM_THREESCALE_GRPC_CONN_MAX_SECONDS: 60
+  PARAM_USE_CACHED_BACKEND: false
+  PARAM_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS: 15
+  PARAM_BACKEND_CACHE_POLICY_FAIL_CLOSED: true
 ----
 
 .3scale parameters
@@ -102,4 +105,20 @@ threeScale:
 |Sets the maximum amount of seconds (+/-10% jitter) a connection may exist before it is closed
 |Time period in seconds
 |60
+
+
+|`PARAM_USE_CACHE_BACKEND`
+|If true, attempt to create an in-memory apisonator cache for authorization requests
+|`true`/`false`
+|`false`
+
+|`PARAM_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS`
+|If the backend cache is enabled, this sets the interval in seconds for flushing the cache against 3scale
+|Time period in seconds
+|15
+
+|`PARAM_BACKEND_CACHE_POLICY_FAIL_CLOSED`
+|Whenever the backend cache cannot retrieve authorization data, whether to deny (closed) or allow (open) requests
+|`true`/`false`
+|`true`
 |===

--- a/modules/ossm-threescale-integrate-1x.adoc
+++ b/modules/ossm-threescale-integrate-1x.adoc
@@ -15,9 +15,6 @@ You can use these examples to configure requests to your services using the 3sca
 * A working 3scale account (link:https://www.3scale.net/signup/[SaaS] or link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.5/html/installing_3scale/onpremises-installation[3scale 2.5 On-Premises])
 * Enabling backend cache requires 3scale 2.9 or greater
 * {ProductName} prerequisites
-* Ensure Mixer policy enforcement is enabled. Update Mixer policy enforcement section provides instructions to check the current Mixer policy enforcement status and enable policy enforcement.
-
-IMPORTANT: When you want to enable 3scale backend cache with the 3scale Istio adapter, you must also enable mixer policy and mixer telemetry. See xref:../../service_mesh/v2x/installing-ossm.adoc#ossm-control-plane-deploy_installing-ossm[Deploying the Red Hat OpenShift Service Mesh control plane].
 
 [NOTE]
 ====


### PR DESCRIPTION
I made a mistake in the last PR, which added some 2x content, including a link to a 2x module into a 1x module. I've fixed it and am confident the content is in the right place. 

This may still fail, but I think we're moving in the right direction here. And I think this is about right. @fbolton 